### PR TITLE
Implement data collection for pretest and add collected data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+config.py
+.ipynb_checkpoints
+__pycache__

--- a/collect_data_using_youtube_api.ipynb
+++ b/collect_data_using_youtube_api.ipynb
@@ -1,0 +1,293 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Collecting data using youtube api"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1. 검색어를 넣어 검색된 결과 영상들의 채널 목록을 가져온다\n",
+    "2. 채널 목록에 있는 채널들의 플레이리스트 아이디를 가져온다\n",
+    "3. 플레이리스트 목록에 있는모든 영상 목록을 가져온다\n",
+    "4. 영상 목록의 조회수를 찾아 추가한다"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from googleapiclient.discovery import build\n",
+    "import config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "youtube = build('youtube', 'v3', developerKey = config.API_KEY)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. 검색어를 넣어 검색된 결과 영상들의 채널 목록을 가져온다 (channelId)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "channel_list = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_youtube_channel_search_list(keyword):\n",
+    "    page_token = ''\n",
+    "    \n",
+    "    while (True):\n",
+    "        search_response = youtube.search().list(\n",
+    "            q = keyword,\n",
+    "            part = 'snippet',\n",
+    "            maxResults = 50,\n",
+    "            pageToken = page_token, \n",
+    "        ).execute()\n",
+    "        \n",
+    "        for item in search_response['items']:\n",
+    "            if (item['id']['kind']=='youtube#video'):\n",
+    "                channel_list.append(item['snippet']['channelId'])\n",
+    "            elif (item['id']['kind']=='youtube#channel'):\n",
+    "                channel_list.append(item['id']['channelId'])\n",
+    "                \n",
+    "        if ('nextPageToken' in search_response):\n",
+    "            page_token = search_response['nextPageToken']\n",
+    "        else:\n",
+    "            break               \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_youtube_channel_search_list('브이로그')\n",
+    "channel_list = pd.DataFrame(channel_list, columns = ['channel_id'])\n",
+    "print('data num: ' + str(len(channel_list)))\n",
+    "channel_list.head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "channel_list = channel_list.drop_duplicates()\n",
+    "print('unique data num: ' + str(len(channel_list)))\n",
+    "channel_list = channel_list.reset_index().drop('index', 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. 채널 목록에 있는 채널들의 플레이리스트 아이디를 가져온다"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "playlist_ids_of_channel = []\n",
+    "\n",
+    "for channel_id in channel_list['channel_id']:\n",
+    "    content = youtube.channels().list(id = channel_id, \n",
+    "                                      part = 'contentDetails').execute()\n",
+    "    playlist_id = content['items'][0]['contentDetails']['relatedPlaylists']['uploads']\n",
+    "    playlist_ids_of_channel.append(playlist_id)\n",
+    "    \n",
+    "print('data num: ' + str(len(playlist_ids_of_channel))) # should be same as len(channel_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "channel_list['playlist_id'] = playlist_ids_of_channel\n",
+    "channel_list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3. 플레이리스트 목록에 있는모든 영상 목록을 가져온다"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(\n",
+    "        columns = ['title', 'video_id', 'channel_name', 'channel_id', 'publish_time'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_youtube_video_data(playlist_id):\n",
+    "    page_token = ''\n",
+    "    \n",
+    "    while (True):\n",
+    "        response = youtube.playlistItems().list(\n",
+    "            playlistId = playlist_id,\n",
+    "            part = 'snippet',\n",
+    "            maxResults = 50,\n",
+    "            pageToken = page_token\n",
+    "        ).execute()\n",
+    "        \n",
+    "        for item in response['items']:\n",
+    "            title = item['snippet']['title']\n",
+    "            video_id = item['snippet']['resourceId']['videoId']\n",
+    "            channel_name = item['snippet']['channelTitle']\n",
+    "            channel_id = item['snippet']['channelId']\n",
+    "            publish_time = item['snippet']['publishedAt']\n",
+    "            global df\n",
+    "            df = df.append(\n",
+    "                {'title': title, 'video_id': video_id, 'channel_name': channel_name, \n",
+    "                 'channel_id': channel_id, 'publish_time': publish_time},\n",
+    "                ignore_index=True)\n",
+    "\n",
+    "        if ('nextPageToken' in response):\n",
+    "            page_token = response['nextPageToken']\n",
+    "        else:\n",
+    "            break"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for playlist_id in channel_list['playlist_id']:\n",
+    "    get_youtube_video_data(playlist_id)\n",
+    "\n",
+    "print('data num: ' + str(len(df)))\n",
+    "df.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4. 영상 목록의 조회수를 찾아 추가한다"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['views'] = -1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "for index in range(0, len(df)):\n",
+    "    response = youtube.videos().list(\n",
+    "        part = 'statistics', id = df.loc[index, 'video_id']).execute()\n",
+    "    if len(response['items']) > 0:\n",
+    "        df.loc[index, 'views'] = response['items'][0]['statistics'].get('viewCount')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('data num: ' + str(len(df)))\n",
+    "df.head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = df.dropna(axis=0)\n",
+    "indexNames = df[ (df['views'] == -1) | (df['views'] is None) ].index\n",
+    "df.drop(indexNames , inplace=True)\n",
+    "print('data num: ' + str(len(df)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.to_csv('vlog_data.csv', index = False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
**[PR 요약]**
아이디어 검증을 위해 필요한 데이터를 수집했습니다.

search/list api만 사용해서는 영상을 몇백개밖에 수집하지 못해서 아래와 같은 방식으로 작업했습니다. 

1. 검색어를 넣어 검색된 결과 영상들의 채널 목록을 가져온다
2. 채널 목록에 있는 채널들의 플레이리스트 아이디를 가져온다
3. 플레이리스트 목록에 있는모든 영상 목록을 가져온다
4. 영상 목록의 조회수를 찾아 추가한다


**[주의할 점]**
- api 사용량 제한이 있어 조회수 수집은 21.04.02~21.04.04 동안 이루어졌습니다. 조회수를 가져온 시점에 따라 조회수가 다른 점 유의바랍니다.
- '브이로그'를 검색어로 넣고 검색 결과의 영상을 올린 채널을 수집한 다음, 그 채널들의 모든 영상을 가져왔기 때문에 브이로그와 관련없는 영상이 많습니다. 추후 모델링 및 정확성 검증 작업 시 참고 바랍니다.